### PR TITLE
Disable Jenkins 2.x splashscreen

### DIFF
--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -1,9 +1,10 @@
 import os
 
+from charmhelpers.core import host
 from charmhelpers.core import hookenv
 from charmhelpers.core import templating
 
-from charms.layer.jenkins.paths import CONFIG_FILE
+from charms.layer.jenkins.paths import CONFIG_FILE, HOME
 
 PORT = 8080
 
@@ -24,6 +25,21 @@ class Configuration(object):
         self._hookenv = hookenv
         self._templating = templating
 
+    def _disable_splashscreen(self):
+        """Disable the splash screen for 2.x releases of jenkins"""
+        import pwd
+        import grp
+        uid = pwd.getpwnam('jenkins').pw_uid
+        gid = grp.getgrnam('jenkins').gr_gid
+        splash_version_ran = os.path.join(
+            HOME, 'jenkins.install.InstallUtil.lastExecVersion')
+        version_installed = os.path.join(
+            HOME, 'jenkins.install.UpgradeWizard.state')
+        if not os.path.lexists(splash_version_ran):
+            host.symlink(version_installed, splash_version_ran)
+            os.fchown(splash_version_ran, uid, gid)
+            os.fchown(splash_version_ran, uid, gid)
+
     def bootstrap(self):
         """Generate Jenkins' config, if it hasn't done yet."""
         config = self._hookenv.config()
@@ -39,6 +55,7 @@ class Configuration(object):
         self._templating.render(
             "jenkins-config.xml", CONFIG_FILE, context,
             owner="jenkins", group="nogroup")
+        self._disable_splashscreen()
 
         config["_config-bootstrapped"] = True
 

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -30,14 +30,13 @@ class Configuration(object):
         import pwd
         import grp
         uid = pwd.getpwnam('jenkins').pw_uid
-        gid = grp.getgrnam('jenkins').gr_gid
+        gid = grp.getgrnam('nogroup').gr_gid
         splash_version_ran = os.path.join(
             HOME, 'jenkins.install.InstallUtil.lastExecVersion')
         version_installed = os.path.join(
             HOME, 'jenkins.install.UpgradeWizard.state')
         if not os.path.lexists(splash_version_ran):
             host.symlink(version_installed, splash_version_ran)
-            os.fchown(splash_version_ran, uid, gid)
             os.fchown(splash_version_ran, uid, gid)
 
     def bootstrap(self):

--- a/lib/charms/layer/jenkins/configuration.py
+++ b/lib/charms/layer/jenkins/configuration.py
@@ -37,7 +37,7 @@ class Configuration(object):
             HOME, 'jenkins.install.UpgradeWizard.state')
         if not os.path.lexists(splash_version_ran):
             host.symlink(version_installed, splash_version_ran)
-            os.fchown(splash_version_ran, uid, gid)
+            os.chown(splash_version_ran, uid, gid, follow_symlinks=False)
 
     def bootstrap(self):
         """Generate Jenkins' config, if it hasn't done yet."""

--- a/reactive/jenkins.py
+++ b/reactive/jenkins.py
@@ -9,6 +9,7 @@ from charmhelpers.core.host import (
 from charms.reactive import (
     hook,
     when,
+    when_any,
     when_not,
     only_once,
     set_state,
@@ -88,8 +89,8 @@ def configure_tools():
 
 # Called once we're bootstrapped and every time the configured user
 # changes.
-@when("jenkins.bootstrapped", "config.changed.username")
-@when("jenkins.bootstrapped", "config.changed.password")
+@when("jenkins.bootstrapped")
+@when_any("config.changed.username", "config.changed.password")
 def configure_admin():
     remove_state("jenkins.configured.admin")
     status_set("maintenance", "Configuring admin user")


### PR DESCRIPTION
I forked this a while back. Looks like you fixed the username/password bug already (will remove that from here so it can merge cleanly in a bit).

The only other thing added is disabling the 2.x splashscreen.